### PR TITLE
Do not leak open files

### DIFF
--- a/user_clipboard/models.py
+++ b/user_clipboard/models.py
@@ -78,7 +78,13 @@ class Clipboard(models.Model):
 
     def get_thumbnail_url(self):
         if self.is_image and self.file:
-            return self.image_thumbnail.url
+            # Work around bug in django-imagekit (https://github.com/matthewwithanm/django-imagekit/issues/429)
+            closed = self.file.closed
+            try:
+                return self.image_thumbnail.url
+            finally:
+                if closed:
+                    self.file.close()
 
     @property
     def thumbnail(self):

--- a/user_clipboard/tests/forms.py
+++ b/user_clipboard/tests/forms.py
@@ -25,6 +25,12 @@ class ModelWithFileForm(forms.ModelForm):
                 raise forms.ValidationError('Error processing document. Please upload it again.')
         return None
 
+    def save(self):
+        try:
+            return super(ModelWithFileForm, self).save()
+        finally:
+            self.cleaned_data['document'].close()
+
 
 class ModelWithImageForm(forms.ModelForm):
 
@@ -47,3 +53,9 @@ class ModelWithImageForm(forms.ModelForm):
             except Clipboard.DoesNotExist:
                 raise forms.ValidationError('Error processing image. Please upload it again.')
         return None
+
+    def save(self):
+        try:
+            return super(ModelWithImageForm, self).save()
+        finally:
+            self.cleaned_data['image'].close()


### PR DESCRIPTION
This can lead to memory leak on Python 3 because of the warnings.

Adds workaround for issue in Django ImageKit (matthewwithanm/django-imagekit#429)